### PR TITLE
Update README with Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@
 
 ## Requirement
 
+## Prerequisites
+
+- An Azure subscription - [Create one for free](https://azure.microsoft.com/free/cognitive-services?azure-portal=true)
+- Access granted to the Azure OpenAI service in the desired Azure subscription. Currently, access to this service is granted only by application. You can apply for access to Azure OpenAI Service by completing the form at [https://aka.ms/oai/access](https://aka.ms/oai/access?azure-portal=true).
+- The current version of the [Java Development Kit (JDK)](https://www.microsoft.com/openjdk)
+- The [Spring Boot CLI tool](https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html#getting-started.installing.cli)
+- An Azure OpenAI Service resource with the gpt-3.5-turbo model deployed. For more information about model deployment, see the [resource deployment guide](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource).
+
 ## Usage
 
 ## Installation


### PR DESCRIPTION
Related to #1

Updates the `README.md` file to include a new "Prerequisites" section before the "Usage" section. 

- Adds a list of prerequisites necessary for using the repository, including an Azure subscription, access to the Azure OpenAI service, the current version of the JDK, the Spring Boot CLI tool, and an Azure OpenAI Service resource with the gpt-3.5-turbo model deployed.
- Provides links to external resources for each prerequisite to assist users in meeting these requirements.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/1?shareId=850f3d1d-5b1b-4237-9a57-6cb44cc4f800).