### PR TITLE
Add Spring AI dependency for Azure OpenAI Service

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -16,6 +16,16 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
+	<repositories>
+		<repository>
+			<id>spring-snapshots</id>
+			<name>Spring Snapshots</name>
+			<url>https://repo.spring.io/snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -26,6 +36,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.azure.spring</groupId>
+			<artifactId>azure-spring-boot-starter-ai-openai</artifactId>
+			<version>1.0.0-beta.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Related to #3

Updates the `pom.xml` file to include Spring AI dependency for Azure OpenAI Service and adds the Maven repository for Spring Snapshots.

- Adds the Spring Snapshots repository within the `<repositories>` section, enabling snapshots to ensure the latest versions of dependencies are used.
- Includes a new dependency for Spring AI for Azure OpenAI Service under the `<dependencies>` section, specifying version `1.0.0-beta.1` to integrate Azure OpenAI capabilities into the project.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/3?shareId=3ca63fcf-1529-49d5-a831-84baaf98f073).