### PR TITLE
Integrate spring-boot-starter-web

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -22,7 +22,10 @@
       <groupId>org.springframework.ai</groupId>
       <artifactId>spring-ai-azure-openai-spring-boot-starter</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
Related to #7

This pull request adds the `spring-boot-starter-web` dependency to the `pom.xml` file, enabling REST application capabilities for the Spring project.

- Adds `spring-boot-starter-web` dependency to the `<dependencies>` section, ensuring the project can handle web requests.
- Maintains the Spring AI version at 0.8.1, aligning with the project's specifications for Spring AI integration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/7?shareId=e29a320c-58b3-4c52-b9f0-ae0b887163b7).