### PR TITLE
Add Spring AI Azure OpenAI properties to application.yml

### DIFF
--- a/workspace/src/main/resources/application.yml
+++ b/workspace/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  ai:
+    azure:
+      openai:
+        api-key: YOUR_API_KEY
+        endpoint: YOUR_ENDPOINT
+        embedding:
+          options:
+            model: YOUR_MODEL_DEPLOYMENT_NAME


### PR DESCRIPTION
Related to #9

Adds the specified Spring AI Azure OpenAI properties to the `application.yml` file under `src/main/resources`.

- Creates the `application.yml` file in the correct directory, ensuring it's properly loaded by Spring Boot.
- Defines the properties `spring.ai.azure.openai.api-key`, `spring.ai.azure.openai.endpoint`, and `spring.ai.azure.openai.embedding.options.model` as specified in the issue.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/9?shareId=2c8bbc9c-537b-4a4a-9882-3f192b2249e0).