### PR TITLE
Add SimpleAiController with ChatClient injection

### DIFF
--- a/workspace/src/main/java/com/example/demo/SimpleAiController.java
+++ b/workspace/src/main/java/com/example/demo/SimpleAiController.java
@@ -1,0 +1,16 @@
+package com.example.demo;
+
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    @Autowired
+    public SimpleAiController(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+}


### PR DESCRIPTION
Related to #11

Adds a new REST controller class named `SimpleAiController` to the project.
- Implements the class `SimpleAiController` within the `com.example.demo` package.
- Annotates the class with `@RestController` to define it as a controller in the Spring Boot framework.
- Injects `ChatClient` dependency through the constructor, ensuring dependency injection is utilized for better testability and decoupling.
- Marks the constructor with `@Autowired` to automate the injection process by Spring's dependency injection facilities.
- Declares a private final field of type `ChatClient` named `chatClient` to hold the injected instance.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/11?shareId=72a582ad-d0f2-43c9-a659-b2985e0989dd).