### PR TITLE
Add generate method to SimpleAiController

### DIFF
--- a/workspace/src/main/java/com/example/demo/SimpleAiController.java
+++ b/workspace/src/main/java/com/example/demo/SimpleAiController.java
@@ -2,6 +2,8 @@ package com.example.demo;
 
 import org.springframework.ai.chat.ChatClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,5 +14,10 @@ public class SimpleAiController {
     @Autowired
     public SimpleAiController(ChatClient chatClient) {
         this.chatClient = chatClient;
+    }
+
+    @GetMapping("/generate")
+    public String generate(@RequestParam(value = "message", defaultValue = "Tell me a funny joke in Japanese") String message) {
+        return chatClient.generate(message);
     }
 }


### PR DESCRIPTION
Related to #13

Adds a new `generate` method to the `SimpleAiController` class to handle GET requests with a default message parameter.
- Implements the `@GetMapping` annotation to map the `/generate` endpoint.
- Introduces a `message` parameter with a default value of "Tell me a funny joke in Japanese" using the `@RequestParam` annotation.
- Utilizes the `chatClient` to generate and return a response based on the provided `message` parameter.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/13?shareId=3e98fd44-f992-498e-83b8-6ce88c685c24).