### PR TITLE
Update generate method endpoint

### DIFF
--- a/workspace/src/main/java/com/example/demo/SimpleAiController.java
+++ b/workspace/src/main/java/com/example/demo/SimpleAiController.java
@@ -1,7 +1,6 @@
 package com.example.demo;
 
 import org.springframework.ai.chat.ChatClient;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,13 +10,12 @@ public class SimpleAiController {
 
     private final ChatClient chatClient;
 
-    @Autowired
     public SimpleAiController(ChatClient chatClient) {
         this.chatClient = chatClient;
     }
 
-    @GetMapping("/generate")
+    @GetMapping("/ai/joke")
     public String generate(@RequestParam(value = "message", defaultValue = "Tell me a funny joke in Japanese") String message) {
-        return chatClient.generate(message);
+        return chatClient.call(message);
     }
 }


### PR DESCRIPTION
Related to #13

Updates the `generate` method in `SimpleAiController` to enhance functionality and align with project specifications.
- Changes the endpoint mapping from "/generate" to "/ai/joke" to better reflect the method's purpose.
- Replaces the `generate` method call with `call` on the `ChatClient` to align with the intended Azure OpenAI integration.
- Removes the `@Autowired` annotation, utilizing constructor injection for `ChatClient` dependency, simplifying the code structure.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/13?shareId=8d10492d-fe5b-4be7-932f-d0702c815110).