### PR TITLE
Update groupId to com.microsoft.shinyay

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -8,7 +8,7 @@
     <version>3.2.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
-  <groupId>com.example</groupId>
+  <groupId>com.microsoft.shinyay</groupId>
   <artifactId>demo</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>demo</name>


### PR DESCRIPTION
Related to #16

Updates the `groupId` in `pom.xml` to align with project requirements.

- Changes the `groupId` from `com.example` to `com.microsoft.shinyay` in `workspace/pom.xml`, ensuring the project's `groupId` matches the specified requirement in the issue.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/16?shareId=01d28f86-3a59-4fb4-a334-f7b1b77bc382).