### PR TITLE
Add Spring AI Azure OpenAI properties to application.yml

### DIFF
--- a/workspace/src/main/resources/application.yml
+++ b/workspace/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  ai:
+    azure:
+      openai:
+        api-key: "YOUR_API_KEY"
+        endpoint: "YOUR_ENDPOINT"
+        embedding:
+          options:
+            deployment-name: "YOUR_MODEL_NAME"


### PR DESCRIPTION
Related to #18

Adds the `application.yml` file under `workspace/src/main/resources` with Spring AI Azure OpenAI properties.

- Introduces a new `application.yml` file to the project, ensuring the application can be configured with Azure OpenAI properties.
- Specifies placeholders for `api-key`, `endpoint`, and `deployment-name` under the `spring.ai.azure.openai` hierarchy, aligning with the project's need for external configuration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/18?shareId=97048a17-f46b-48fd-89a2-ad4b77375d0d).