### PR TITLE
Add SimpleAiController with ChatClient

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -24,6 +24,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/workspace/src/main/java/com/example/demo/SimpleAiController.java
+++ b/workspace/src/main/java/com/example/demo/SimpleAiController.java
@@ -1,0 +1,22 @@
+package com.example.demo;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.ai.chat.ChatClient;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    @Autowired
+    public SimpleAiController(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    @GetMapping("/test")
+    public String testEndpoint() {
+        return "Test endpoint is working!";
+    }
+}


### PR DESCRIPTION
Related to #20

Adds a REST controller for Azure OpenAI service integration and updates Maven dependencies.
- Adds the `spring-boot-starter-web` dependency to `pom.xml` to enable REST controller support.
- Creates a new `SimpleAiController` class with a `@RestController` annotation, enabling it as a REST controller within the Spring Boot application.
- Implements Constructor Dependency Injection for `ChatClient` in `SimpleAiController`, ensuring that `ChatClient` is properly initialized and available for use.
- Adds a sample GET endpoint `/test` to `SimpleAiController` that returns a simple string response, demonstrating the controller's functionality.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/20?shareId=5ca23b23-fd66-4fed-9b87-825f04f1fa41).