### PR TITLE
Add view for SimpleAiController with Thymeleaf

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -31,6 +31,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Thymeleaf dependency added for view templates processing -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/workspace/src/main/java/com/example/demo/SimpleAiController.java
+++ b/workspace/src/main/java/com/example/demo/SimpleAiController.java
@@ -1,12 +1,14 @@
 package com.example.demo;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.ai.chat.ChatClient;
 
-@RestController
+@Controller
 public class SimpleAiController {
 
     private final ChatClient chatClient;
@@ -16,14 +18,16 @@ public class SimpleAiController {
         this.chatClient = chatClient;
     }
 
-    @GetMapping("/test")
-    public String testEndpoint() {
-        return "Test endpoint is working!";
+    @GetMapping("/")
+    public String greetingForm(Model model) {
+        model.addAttribute("message", new String());
+        return "simple-ai-view";
     }
 
-    @GetMapping("/ai/recipe")
-    public String generate(
-            @RequestParam(value = "message", defaultValue = "Can you give me a recipe for a delicious dish in Japanese?") String message) {
-        return chatClient.call(message);
+    @PostMapping("/ai/recipe")
+    public String generate(@RequestParam(value = "message", defaultValue = "Can you give me a recipe for a delicious dish in Japanese?") String message, Model model) {
+        String response = chatClient.call(message);
+        model.addAttribute("response", response);
+        return "simple-ai-view";
     }
 }

--- a/workspace/src/main/resources/application.yml
+++ b/workspace/src/main/resources/application.yml
@@ -7,3 +7,7 @@ spring:
         embedding:
           options:
             deployment-name: "shinyay-gpt"
+  thymeleaf:
+    cache: false
+    prefix: classpath:/templates/
+    suffix: .html

--- a/workspace/src/main/resources/templates/simple-ai-view.html
+++ b/workspace/src/main/resources/templates/simple-ai-view.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple AI View</title>
+</head>
+<body>
+    <h2>Simple AI Interaction</h2>
+    <form action="#" th:action="@{/ai/recipe}" method="post">
+        <p>
+            <label for="message">Prompt:</label>
+            <input type="text" id="message" name="message" />
+        </p>
+        <p>
+            <input type="submit" value="Submit" />
+        </p>
+    </form>
+    <div>
+        <p>Response:</p>
+        <p th:text="${response}"></p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Related to #24

Adds a Thymeleaf view for SimpleAiController and configures the application to support template processing.
- Adds Thymeleaf dependency to `pom.xml` to enable view templates processing.
- Updates `SimpleAiController` to serve a Thymeleaf template `simple-ai-view.html` for the root endpoint and handle form submissions, returning the view with a model attribute for the response.
- Adds Thymeleaf configuration properties to `application.yml` for template prefix and suffix.
- Creates a new Thymeleaf template `simple-ai-view.html` in `src/main/resources/templates` with a form for input prompts, a submit button, and a section to display the response.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/24?shareId=4342d9cc-a288-4c8f-ad3b-a50b3f10e8a7).