### PR TITLE
Update Maven artifactId to java-on-azure

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.microsoft.shinyay</groupId>
-	<artifactId>spring-ai</artifactId>
+	<artifactId>java-on-azure</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>spring-ai</name>
 	<description>Demo project for Spring Boot</description>


### PR DESCRIPTION
Related to #30

Updates the Maven configuration to align with project specifications.

- Changes the `<artifactId>` in `workspace/pom.xml` to `java-on-azure` to match the specified artifact name in the project requirements.
- Maintains the `<groupId>` as `com.microsoft.shinyay`, ensuring consistency with the initial project setup.
- Confirms the inclusion of `spring-ai-azure-openai-spring-boot-starter` dependency and the `spring-ai-bom` with version `0.8.1` for consistent versioning across Spring AI dependencies.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/30?shareId=86418dbf-3746-4211-8250-8dce3dbcdfd0).