### PR TITLE
Add SimpleAiController with ChatClient

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/controller/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/controller/SimpleAiController.java
@@ -1,0 +1,23 @@
+package com.microsoft.shinyay.ai.controller;
+
+import com.microsoft.shinyay.ai.service.ChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    @Autowired
+    public SimpleAiController(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    @GetMapping("/ai/joke")
+    public String getJoke() {
+        // Assuming ChatClient has a method generateJoke() to generate a joke
+        return chatClient.generateJoke();
+    }
+}


### PR DESCRIPTION
Related to #34

Implements a new REST controller `SimpleAiController` with a joke generation feature using `ChatClient`.

- Adds `SimpleAiController` class under `com.microsoft.shinyay.ai.controller` package.
- Utilizes `@RestController` annotation to define the class as a REST controller.
- Injects `ChatClient` dependency through constructor injection for use in the controller.
- Defines a GET endpoint `/ai/joke` that returns a joke generated by `ChatClient`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/34?shareId=64c8477e-fa3c-48c0-abed-816345e01313).