### PR TITLE
Add endpoint for food recipe in Japanese

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -13,9 +13,9 @@ public class SimpleAiController {
         this.chatClient = chatClient;
     }
 
-    @GetMapping("/ai/joke")
-    public String getJoke() {
-        // Assuming the ChatClient has a method to generate a joke
-        return chatClient.generateJoke();
+    @GetMapping("/ai/recipe")
+    public String generateRecipe() {
+        // Assuming the ChatClient has a method to call Azure OpenAI Service
+        return chatClient.call("Tell me a delicious food recipe in Japanese");
     }
 }


### PR DESCRIPTION
Related to #37

Introduces a new endpoint "/ai/recipe" to generate a delicious food recipe in Japanese using Azure OpenAI Service.

- Renames the method `getJoke` to `generateRecipe` to reflect its new functionality.
- Changes the `@GetMapping` value from "/ai/joke" to "/ai/recipe", establishing the new endpoint.
- Updates the method to use `chatClient.call` with the prompt "Tell me a delicious food recipe in Japanese", leveraging Azure OpenAI Service for generating responses.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/37?shareId=bdca0c02-cb84-471e-8a15-1d48ba7a4d16).