### PR TITLE
Add view with input, results, and buttons styled with CSS

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -1,10 +1,15 @@
 package com.microsoft.shinyay.ai;
 
 import org.springframework.ai.chat.ChatClient;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
-@RestController
+@Controller
+@RequestMapping("/ai")
 public class SimpleAiController {
 
     private final ChatClient chatClient;
@@ -13,9 +18,29 @@ public class SimpleAiController {
         this.chatClient = chatClient;
     }
 
-    @GetMapping("/ai/recipe")
-    public String generateRecipe() {
+    @GetMapping("/recipe")
+    public String generateRecipeForm(Model model) {
+        model.addAttribute("prompt", new Prompt());
+        return "simple-ai-view";
+    }
+
+    @PostMapping("/recipe")
+    public String generateRecipe(@ModelAttribute Prompt prompt, Model model) {
         // Assuming the ChatClient has a method to call Azure OpenAI Service
-        return chatClient.call("Tell me a delicious food recipe in Japanese");
+        String result = chatClient.call(prompt.getText());
+        model.addAttribute("result", result);
+        return "simple-ai-view";
+    }
+
+    static class Prompt {
+        private String text;
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
     }
 }

--- a/workspace/src/main/resources/static/css/style.css
+++ b/workspace/src/main/resources/static/css/style.css
@@ -1,0 +1,48 @@
+/* Styles for Simple AI View components */
+
+.container {
+    max-width: 800px;
+    margin: auto;
+    padding: 20px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-control {
+    width: 100%;
+    padding: 10px;
+    margin: 5px 0 22px 0;
+    display: inline-block;
+    border: none;
+    background: #f1f1f1;
+}
+
+.form-control:focus {
+    background-color: #ddd;
+    outline: none;
+}
+
+.btn {
+    background-color: #4CAF50;
+    color: white;
+    padding: 14px 20px;
+    margin: 8px 0;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+    opacity: 0.9;
+}
+
+.btn:hover {
+    opacity: 1;
+}
+
+.btn-primary {
+    background-color: #007bff;
+}
+
+.btn-secondary {
+    background-color: #6c757d;
+}

--- a/workspace/src/main/resources/templates/simple-ai-view.html
+++ b/workspace/src/main/resources/templates/simple-ai-view.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple AI View</title>
+    <link rel="stylesheet" href="../static/css/style.css">
+</head>
+<body>
+    <div class="container">
+        <form action="#" th:action="@{/ai/recipe}" method="post">
+            <div class="form-group">
+                <label for="prompt">Prompt:</label>
+                <input type="text" id="prompt" name="prompt" th:field="*{prompt}" class="form-control"/>
+            </div>
+            <div class="form-group">
+                <label for="result">Result:</label>
+                <textarea id="result" name="result" class="form-control" readonly></textarea>
+            </div>
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">Submit</button>
+                <button type="reset" class="btn btn-secondary">Clear</button>
+            </div>
+        </form>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Related to #39

Implements a Thymeleaf view for SimpleAiController with styled components and updates the controller to support form submission and result display.

- **View Creation and Styling**
  - Adds a new Thymeleaf template `simple-ai-view.html` in `src/main/resources/templates` to define the user interface.
  - Introduces a CSS file `style.css` in `src/main/resources/static/css` to apply styles to the view components, including the text box, text field, submit button, and clear button.

- **Controller Enhancement**
  - Modifies `SimpleAiController` to serve as a `@Controller` instead of a `@RestController`, enabling it to return views.
  - Implements two methods: `generateRecipeForm` for GET requests to display the form and `generateRecipe` for POST requests to process the form submission and display results.
  - Adds a static inner class `Prompt` to bind form input to a model attribute.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/39?shareId=9a5ac2f4-79f1-44b1-885e-ad3d705d3516).