### PR TITLE
Update Spring AI version and Spring Boot version

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.microsoft.shinyay</groupId>
@@ -21,6 +21,7 @@
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-azure-openai-spring-boot-starter</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Related to #41

Updates Maven project dependencies and Spring Boot version for Azure OpenAI integration.

- Updates the `spring-ai-azure-openai-spring-boot-starter` dependency to version `1.0.0-SNAPSHOT`.
- Upgrades the Spring Boot version to `3.3.0` in the project's parent POM configuration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/41?shareId=c1ead5c4-8ced-4c81-b929-9896edaa15a1).