### PR TITLE
Add SimpleAiController for Azure OpenAI communication

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -23,7 +23,10 @@
 			<artifactId>spring-ai-azure-openai-spring-boot-starter</artifactId>
 			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -1,0 +1,24 @@
+package com.microsoft.shinyay.ai;
+
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    public SimpleAiController(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    @GetMapping("/ai/recipe")
+    public String getRecipe(@RequestParam(value = "userInput", defaultValue = "Tell me a delicious food recipe") String userInput) {
+        return chatClient.prompt()
+                .user(userInput)
+                .call()
+                .content();
+    }
+}


### PR DESCRIPTION
Related to #45

Adds a REST controller for Azure OpenAI service integration and updates Maven dependencies to support web capabilities.

- Adds the `spring-boot-starter-web` dependency to `pom.xml` to enable REST capabilities in the Spring Boot application.
- Creates a new `SimpleAiController` class within the `com.microsoft.shinyay.ai` package, which includes:
  - Importing and utilizing the `ChatClient` interface from `org.springframework.ai.chat` for Azure OpenAI communication.
  - A constructor for dependency injection of `ChatClient`.
  - A GET endpoint `/ai/recipe` that accepts user input as a request parameter and uses `ChatClient` to send prompts and call responses from Azure OpenAI, returning the content of the response.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/45?shareId=c5de6f07-7179-4aeb-a2ee-afdd5d8aa61d).