### PR TITLE
Update Spring AI version and add Azure OpenAI configuration

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.microsoft.shinyay</groupId>
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>21</java.version>
-		<spring-ai.version>0.8.1</spring-ai.version>
+		<spring-ai.version>1.0.0-M1</spring-ai.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/workspace/src/main/resources/application.yml
+++ b/workspace/src/main/resources/application.yml
@@ -1,1 +1,9 @@
-
+spring:
+  ai:
+    azure:
+      openai:
+        api-key: ${SPRING_AI_AZURE_OPENAI_API_KEY}
+        endpoint: ${SPRING_AI_AZURE_OPENAI_ENDPOINT}
+        embedding:
+          options:
+            deployment-name: ${SPRING_AI_AZURE_OPENAI_EMBEDDING_OPTIONS_DEPLOYMENT_NAME}


### PR DESCRIPTION
Related to #49

Updates Maven project configuration for Spring AI and Azure OpenAI integration.

- **Updates `pom.xml`**:
  - Updates Spring Boot version to `3.3.0`.
  - Updates Spring AI version to `1.0.0-M1`.
- **Populates `application.yml`**:
  - Adds Azure OpenAI configuration properties including API key, endpoint, and embedding options deployment name.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/49?shareId=a3d50f23-b286-4199-b33e-df14bd38efdd).