### PR TITLE
Update Azure OpenAI Service configuration in application.yml

### DIFF
--- a/workspace/src/main/resources/application.yml
+++ b/workspace/src/main/resources/application.yml
@@ -4,6 +4,6 @@ spring:
       openai:
         api-key: ${SPRING_AI_AZURE_OPENAI_API_KEY}
         endpoint: ${SPRING_AI_AZURE_OPENAI_ENDPOINT}
-        embedding:
+        chat:
           options:
             deployment-name: ${SPRING_AI_AZURE_OPENAI_EMBEDDING_OPTIONS_DEPLOYMENT_NAME}


### PR DESCRIPTION
Related to #51

Updates the `application.yml` configuration for Azure OpenAI Service.

- Replaces `embedding.options.deployment-name` with `chat.options.deployment-name` to align with the correct configuration properties for Azure OpenAI Service.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/51?shareId=5b9c022e-6a90-45ed-8399-2256b04bbf2f).