### PR TITLE
Add SimpleAiController for Azure OpenAI interactions

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -24,6 +24,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -1,0 +1,22 @@
+package com.microsoft.shinyay.ai;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    @Autowired
+    public SimpleAiController(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
+
+    @GetMapping("/prompt")
+    public String sendPromptAndReceiveResponse(String prompt) {
+        return chatClient.prompt().user(prompt).call().content();
+    }
+}


### PR DESCRIPTION
Related to #53

Introduces a new REST controller for interacting with Azure OpenAI and updates project dependencies to support RESTful operations.

- Adds the `spring-boot-starter-web` dependency to `pom.xml` to enable Spring Web capabilities.
- Creates a new `SimpleAiController` class annotated with `@RestController`, facilitating RESTful web services.
- Injects `ChatClient` into `SimpleAiController` using constructor injection, enabling communication with Azure OpenAI.
- Implements a method `sendPromptAndReceiveResponse` in `SimpleAiController` to send prompts to Azure OpenAI and receive responses, accessible via a GET request to `/prompt`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/53?shareId=58fb3b9e-1820-4c20-a0eb-5d2105b47e45).