### PR TITLE
Update default prompt to discuss Spring Framework benefits

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -3,6 +3,7 @@ package com.microsoft.shinyay.ai;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -16,7 +17,7 @@ public class SimpleAiController {
     }
 
     @GetMapping("/prompt")
-    public String sendPromptAndReceiveResponse(String prompt) {
+    public String sendPromptAndReceiveResponse(@RequestParam(defaultValue = "Tell me about the benefit of Spring Framework") String prompt) {
         return chatClient.prompt().user(prompt).call().content();
     }
 }


### PR DESCRIPTION
Related to #55

Adds a default value to the `prompt` parameter in the `sendPromptAndReceiveResponse` method to enhance user experience by providing a predefined topic of discussion.

- Introduces the `@RequestParam` annotation to the `prompt` parameter in the `sendPromptAndReceiveResponse` method, enabling the handling of HTTP request parameters.
- Sets a default value of "Tell me about the benefit of Spring Framework" for the `prompt` parameter, ensuring that users have a default topic to explore without needing to specify one explicitly.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/55?shareId=39d69888-2a7f-40f4-aceb-1ff952fed1eb).