### PR TITLE
Add Thymeleaf view for SimpleViewController

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -28,6 +28,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleViewController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleViewController.java
@@ -1,0 +1,29 @@
+package com.microsoft.shinyay.ai;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class SimpleViewController {
+
+    private final SimpleAiController simpleAiController;
+
+    public SimpleViewController(SimpleAiController simpleAiController) {
+        this.simpleAiController = simpleAiController;
+    }
+
+    @GetMapping("/")
+    public String simpleView() {
+        return "simple-view";
+    }
+
+    @PostMapping("/generate")
+    public String generatePrompt(@RequestParam("prompt") String prompt, Model model) {
+        String response = simpleAiController.sendPromptAndReceiveResponse(prompt).replace("\n", "<br>");
+        model.addAttribute("response", response);
+        return "simple-view";
+    }
+}

--- a/workspace/src/main/resources/static/css/style.css
+++ b/workspace/src/main/resources/static/css/style.css
@@ -1,0 +1,37 @@
+.container {
+    max-width: 800px;
+    margin: auto;
+    padding: 20px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-control {
+    width: 100%;
+    padding: 10px;
+    margin: 5px 0 22px 0;
+    display: inline-block;
+    border: none;
+    background: #f1f1f1;
+}
+
+.btn {
+    background-color: #4CAF50;
+    color: white;
+    padding: 14px 20px;
+    margin: 8px 0;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+    opacity: 0.9;
+}
+
+.btn:hover {
+    opacity: 1;
+}
+
+.response-area {
+    margin-top: 20px;
+}

--- a/workspace/src/main/resources/static/js/script.js
+++ b/workspace/src/main/resources/static/js/script.js
@@ -1,0 +1,27 @@
+// JavaScript code for handling button actions and AJAX requests
+
+document.addEventListener("DOMContentLoaded", function() {
+    // Attach event listener to form submission
+    document.querySelector("form").addEventListener("submit", function(event) {
+        event.preventDefault(); // Prevent the form from submitting via the browser
+
+        const promptInput = document.querySelector("#prompt").value;
+        fetch("/generate", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: `prompt=${encodeURIComponent(promptInput)}`
+        })
+        .then(response => response.text())
+        .then(data => {
+            document.querySelector("#response").innerHTML = data;
+        })
+        .catch(error => console.error('Error:', error));
+    });
+
+    // Attach event listener to clear button
+    document.querySelector("button[type='reset']").addEventListener("click", function() {
+        document.querySelector("#response").innerHTML = ""; // Clear the response area
+    });
+});

--- a/workspace/src/main/resources/templates/simple-view.html
+++ b/workspace/src/main/resources/templates/simple-view.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple View</title>
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<div class="container">
+    <h2>Simple AI Prompt Generator</h2>
+    <form th:action="@{/generate}" method="post">
+        <div class="form-group">
+            <label for="prompt">Enter your prompt:</label>
+            <input type="text" id="prompt" name="prompt" class="form-control"/>
+        </div>
+        <div class="form-group">
+            <button type="submit" class="btn btn-primary">Submit</button>
+            <button type="reset" class="btn btn-secondary">Clear</button>
+        </div>
+    </form>
+    <div class="response-area">
+        <label for="response">Response:</label>
+        <textarea id="response" name="response" rows="10" class="form-control" readonly="readonly" th:text="${response}"></textarea>
+    </div>
+</div>
+<script src="/js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Related to #57

Implements a Thymeleaf view for `SimpleViewController` with specified components and styles, and adds necessary backend support for form submission.

- **Thymeleaf Integration**: Adds the Thymeleaf dependency to `pom.xml` to enable Thymeleaf support in the project.
- **Controller Setup**: Introduces `SimpleViewController` with methods to handle GET requests for the main page and POST requests for form submissions. The POST handler method utilizes `SimpleAiController` to process prompts and formats the response with HTML `<br>` tags for line breaks.
- **View and Styling**: Creates a Thymeleaf template `simple-view.html` with a form for inputting prompts, a text area for displaying responses, and submit/clear buttons. Adds CSS in `style.css` for basic styling of the form and response area.
- **Client-side Scripting**: Includes a JavaScript file `script.js` to handle form submission via AJAX for a smoother user experience and to clear the response text area when the clear button is clicked.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/57?shareId=9a3ae764-c915-4cfa-8e50-055292232863).