### PR TITLE
Add SimpleAiController with Azure OpenAI ChatClient

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -25,6 +25,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -1,0 +1,23 @@
+package com.microsoft.shinyay.ai;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    @Autowired
+    public SimpleAiController(ChatClient chatClient) {
+        this.chatClient = chatClient;
+    }
+
+    @GetMapping("/prompt")
+    public String sendPromptToAzureOpenAI(@RequestParam(value = "prompt", defaultValue = "Hello, Azure OpenAI!") String prompt) {
+        return chatClient.prompt().user(prompt).call().content();
+    }
+}


### PR DESCRIPTION
Related to #63

Adds a REST controller for interacting with Azure OpenAI and updates Maven dependencies to support web functionalities.
- **Controller Implementation**: Introduces the `SimpleAiController` class annotated with `@RestController`, enabling RESTful web services. This class includes a constructor for `ChatClient` injection and a `@GetMapping` method mapped to the "/prompt" endpoint. The method accepts a "prompt" parameter and utilizes `ChatClient` to send the prompt to Azure OpenAI, returning the response.
- **Maven Dependency Update**: Adds the `spring-boot-starter-web` dependency to `pom.xml`, facilitating the creation of web applications and RESTful services with Spring Boot.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/63?shareId=a2f45251-c166-48d9-a010-601f3101124a).