### PR TITLE
Update prompt method to callAzureOpenAI with new default prompt

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -17,7 +17,7 @@ public class SimpleAiController {
     }
 
     @GetMapping("/prompt")
-    public String sendPromptToAzureOpenAI(@RequestParam(value = "prompt", defaultValue = "Hello, Azure OpenAI!") String prompt) {
+    public String callAzureOpenAI(@RequestParam(value = "prompt", defaultValue = "Tell me the benefit of Spring Framework in Japanese") String prompt) {
         return chatClient.prompt().user(prompt).call().content();
     }
 }


### PR DESCRIPTION
Related to #65

Renames the method and updates the default prompt parameter in `SimpleAiController.java`.

- Renames the method `sendPromptToAzureOpenAI` to `callAzureOpenAI` to align with the specified method name in the issue.
- Updates the default value of the `prompt` parameter to "Tell me the benefit of Spring Framework in Japanese", as per the issue's requirement.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/65?shareId=879aef93-dbd1-48ad-a453-3598e7a55b1c).