### PR TITLE
Add SimpleViewController with Thymeleaf view

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -32,6 +32,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleViewController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleViewController.java
@@ -1,0 +1,29 @@
+package com.microsoft.shinyay.ai;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+public class SimpleViewController {
+
+    private final SimpleAiController aiController;
+
+    public SimpleViewController(SimpleAiController aiController) {
+        this.aiController = aiController;
+    }
+
+    @GetMapping("/")
+    public String simpleView() {
+        return "simple-view";
+    }
+
+    @PostMapping("/submit")
+    public String submitPrompt(@RequestParam("prompt") String prompt, Model model) {
+        String response = aiController.callAzureOpenAI(prompt);
+        model.addAttribute("response", response);
+        return "simple-view";
+    }
+}

--- a/workspace/src/main/resources/static/css/style.css
+++ b/workspace/src/main/resources/static/css/style.css
@@ -1,0 +1,47 @@
+/* Basic styling for the SimpleViewController view */
+.container {
+    max-width: 800px;
+    margin: auto;
+    padding: 20px;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-control {
+    width: 100%;
+    padding: 10px;
+    margin: 5px 0 22px 0;
+    display: inline-block;
+    border: none;
+    background: #f1f1f1;
+}
+
+.form-control:focus {
+    background-color: #ddd;
+    outline: none;
+}
+
+.btn {
+    background-color: #4CAF50;
+    color: white;
+    padding: 14px 20px;
+    margin: 8px 0;
+    border: none;
+    cursor: pointer;
+    width: 100%;
+    opacity: 0.9;
+}
+
+.btn:hover {
+    opacity: 1;
+}
+
+.btn-primary {
+    background-color: #007bff;
+}
+
+.btn-secondary {
+    background-color: #6c757d;
+}

--- a/workspace/src/main/resources/templates/simple-view.html
+++ b/workspace/src/main/resources/templates/simple-view.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Simple View</title>
+    <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}" />
+</head>
+<body>
+<div class="container">
+    <h2>Simple AI Prompt</h2>
+    <form th:action="@{/submit}" method="post">
+        <div class="form-group">
+            <label for="prompt">Prompt:</label>
+            <input type="text" id="prompt" name="prompt" class="form-control" placeholder="Enter your prompt"/>
+        </div>
+        <div class="form-group">
+            <label for="response">Response:</label>
+            <textarea id="response" name="response" class="form-control" readonly="readonly" th:text="${response}"></textarea>
+        </div>
+        <div class="form-group">
+            <button type="submit" class="btn btn-primary">Submit</button>
+            <button type="reset" class="btn btn-secondary">Clear</button>
+        </div>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Related to #67

This pull request introduces a Thymeleaf view for `SimpleViewController` along with the necessary backend support and styling enhancements.

- **Adds Thymeleaf dependency** to `pom.xml` to enable Thymeleaf template processing in the project.
- **Implements `SimpleViewController`** with methods to handle GET and POST requests. The POST method integrates with `SimpleAiController` to process user prompts and return responses.
- **Creates a Thymeleaf template** (`simple-view.html`) that includes a text box for input, a text area for displaying responses, and submit and clear buttons. This template is styled with CSS for a better user experience.
- **Introduces CSS styling** (`style.css`) to improve the appearance of the Thymeleaf view, focusing on form controls and buttons for a cleaner and more interactive interface.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/67?shareId=c2c1f456-03b7-4b8d-aa34-ab018b693579).