### PR TITLE
Update Spring AI integration with Azure OpenAI

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -5,17 +5,17 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.6</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
-	<groupId>com.example</groupId>
-	<artifactId>demo</artifactId>
+	<groupId>com.microsoft.shinyay.ai</groupId>
+	<artifactId>java-on-azure</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>demo</name>
+	<name>Java on Azure</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>21</java.version>
-		<spring-ai.version>0.8.1</spring-ai.version>
+		<spring-ai.version>1.0.0-M1</spring-ai.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/workspace/src/main/resources/application.yml
+++ b/workspace/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  ai:
+    azure:
+      openai:
+        api-key: ${SPRING_AI_AZURE_OPENAI_API_KEY}
+        endpoint: ${SPRING_AI_AZURE_OPENAI_ENDPOINT}
+        chat:
+          options:
+            deployment-name: ${SPRING_AI_AZURE_OPENAI_CHAT_OPTIONS_DEPLOYMENT_NAME}


### PR DESCRIPTION
Related to #69

Updates Maven project configuration for Spring AI integration with Azure OpenAI.

- Updates the `pom.xml` file to use Spring Boot version `3.3.0` and Spring AI version `1.0.0-M1`. This aligns the project with the latest versions for improved features and compatibility.
- Changes the `groupId` to `com.microsoft.shinyay.ai` and the `artifactId` to `java-on-azure`, effectively renaming the project to `Java on Azure`. This better reflects the project's purpose and its alignment with Microsoft Azure technologies.
- Adds necessary Azure OpenAI configuration properties to `application.yml`, including API key and endpoint settings. This enables the project to communicate with Azure OpenAI services.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/69?shareId=8f5a7916-fd17-4cf7-a820-629dde8ef469).