### PR TITLE
Add SimpleAiController to interact with Azure OpenAI

### DIFF
--- a/workspace/pom.xml
+++ b/workspace/pom.xml
@@ -25,6 +25,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -1,0 +1,21 @@
+package com.microsoft.shinyay.ai;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SimpleAiController {
+
+    private final ChatClient chatClient;
+
+    public SimpleAiController() {
+        this.chatClient = new ChatClient.Builder().build();
+    }
+
+    @GetMapping("/prompt")
+    public String getPromptResponse(@RequestParam String prompt) {
+        return chatClient.prompt().user(prompt).call().content();
+    }
+}


### PR DESCRIPTION
Related to #76

Adds a REST controller for interacting with Azure OpenAI and updates Maven dependencies to support web functionalities.
- Adds the `spring-boot-starter-web` dependency to `pom.xml` to enable REST controller capabilities.
- Creates a new `SimpleAiController` class annotated with `@RestController`, establishing it as a REST controller.
- Implements a `getPromptResponse` method within `SimpleAiController` to handle GET requests on the `/prompt` endpoint, accepting a `prompt` parameter and using `ChatClient` to send the prompt to Azure OpenAI and return the response.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/76?shareId=2175d66d-acb2-420f-8a90-43e1d39757c6).