### PR TITLE
Update prompt method with default parameter

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -15,7 +15,7 @@ public class SimpleAiController {
     }
 
     @GetMapping("/prompt")
-    public String getPromptResponse(@RequestParam String prompt) {
+    public String callAzureOpenAI(@RequestParam(defaultValue = "Tell me the benefit of Spring Framework in Japanese") String prompt) {
         return chatClient.prompt().user(prompt).call().content();
     }
 }


### PR DESCRIPTION
Related to #78

Renames a method and adds a default parameter value in the SimpleAiController class to improve functionality and usability.
- Renames the method `getPromptResponse` to `callAzureOpenAI` to better reflect its purpose.
- Adds a default value for the `prompt` parameter, "Tell me the benefit of Spring Framework in Japanese", ensuring a default prompt is used if none is provided.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/78?shareId=e1d2f462-5bdc-4388-898a-73d72d451d1a).