### PR TITLE
Update AI endpoint to /ai/joke

### DIFF
--- a/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
+++ b/workspace/src/main/java/com/microsoft/shinyay/ai/SimpleAiController.java
@@ -14,8 +14,8 @@ public class SimpleAiController {
         this.chatClient = chatClientBuilder.build();
     }
 
-    @GetMapping("/prompt")
-    public String callAzureOpenAI(@RequestParam(defaultValue = "Tell me the benefit of Spring Framework in Japanese") String prompt) {
-        return chatClient.prompt().user(prompt).call().content();
+    @GetMapping("/ai/joke")
+    public String generate(@RequestParam(name = "message", defaultValue = "Tell me a funny joke in Japanese") String message) {
+        return chatClient.prompt().user(message).call().content();
     }
 }


### PR DESCRIPTION
Related to #22

Updates the API endpoint to better align with the intended functionality of generating jokes through Azure OpenAI.

- Renames the endpoint from `/prompt` to `/ai/joke` to reflect its purpose more accurately.
- Changes the method name from `callAzureOpenAI` to `generate` to clarify the action being performed.
- Modifies the request parameter from `prompt` to `message`, aligning with the issue's specification.
- Updates the default message to "Tell me a funny joke in Japanese", making the endpoint's default behavior more specific to generating jokes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shinyay/getting-started-with-azure-openai/issues/22?shareId=95b531b6-847f-4a2d-93ef-dc4d4b0386fa).